### PR TITLE
Skip Remo-E and Remo-E-lite

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -54,11 +54,13 @@ export class NatureRemoPlatform implements DynamicPlatformPlugin {
         this.logger.info('Restoring existing accessory from cache:', existingAccessory.displayName);
         new NatureNemoSensorAccessory(this, existingAccessory);
       } else {
-        this.logger.info('Adding new accessory:', device.name);
-        const accessory = new this.api.platformAccessory(device.name, device.id);
-        accessory.context = { device: device };
-        new NatureNemoSensorAccessory(this, accessory);
-        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+        if (!device.firmware_version.startsWith('Remo-E')) {
+          this.logger.info('Adding new accessory:', device.name);
+          const accessory = new this.api.platformAccessory(device.name, device.id);
+          accessory.context = { device: device };
+          new NatureNemoSensorAccessory(this, accessory);
+          this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+        }
       }
     }
     const appliances = await this.natureRemoApi.getAllAppliances();


### PR DESCRIPTION
Skip NatureNemoSensorAccessory if Remo-E Series

(Remo-E Series has no air quality sensors, so it was always showing 0 like below.)

![Remo-E-lite](https://user-images.githubusercontent.com/36478126/120903423-fbf23480-c680-11eb-99f0-3559abd0fbb2.png)
