### PR TITLE
Repeated serial numbers prevents integration with home assistant

### DIFF
--- a/src/airConAccessory.ts
+++ b/src/airConAccessory.ts
@@ -23,11 +23,12 @@ export class NatureNemoAirConAccessory {
   constructor(
     private readonly platform: NatureRemoPlatform,
     private readonly accessory: PlatformAccessory,
+    private readonly accesory_id: string,
   ) {
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Nature Inc.')
       .setCharacteristic(this.platform.Characteristic.Model, 'Nature Remo series')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'S-e-r-i-a-l');
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accesory_id);
 
     this.service
       = this.accessory.getService(this.platform.Service.Thermostat) || this.accessory.addService(this.platform.Service.Thermostat);

--- a/src/lightAccessory.ts
+++ b/src/lightAccessory.ts
@@ -17,11 +17,12 @@ export class NatureNemoLightAccessory {
   constructor(
     private readonly platform: NatureRemoPlatform,
     private readonly accessory: PlatformAccessory,
+    private readonly appliance_id: string,
   ) {
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Nature Inc.')
       .setCharacteristic(this.platform.Characteristic.Model, 'Nature Remo series')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'S-e-r-i-a-l');
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, appliance_id);
 
     this.service = this.accessory.getService(this.platform.Service.Lightbulb) || this.accessory.addService(this.platform.Service.Lightbulb);
     this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.appliance.nickname);

--- a/src/natureRemoApi.ts
+++ b/src/natureRemoApi.ts
@@ -27,6 +27,7 @@ interface Device {
   id: string;
   name: string;
   firmware_version: string;
+  serial_number: string;
   newest_events: {
     te: {
       val: number;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -52,13 +52,13 @@ export class NatureRemoPlatform implements DynamicPlatformPlugin {
       const existingAccessory = this.accessories.find(accessory => accessory.UUID === device.id);
       if (existingAccessory) {
         this.logger.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-        new NatureNemoSensorAccessory(this, existingAccessory);
+        new NatureNemoSensorAccessory(this, existingAccessory, device.serial_number);
       } else {
         if (!device.firmware_version.startsWith('Remo-E')) {
           this.logger.info('Adding new accessory:', device.name);
           const accessory = new this.api.platformAccessory(device.name, device.id);
           accessory.context = { device: device };
-          new NatureNemoSensorAccessory(this, accessory);
+          new NatureNemoSensorAccessory(this, accessory, device.serial_number);
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
         }
       }
@@ -70,18 +70,18 @@ export class NatureRemoPlatform implements DynamicPlatformPlugin {
         if (existingAccessory) {
           this.logger.info('Restoring existing accessory from cache:', existingAccessory.displayName);
           if (appliance.type === 'LIGHT') {
-            new NatureNemoLightAccessory(this, existingAccessory);
+            new NatureNemoLightAccessory(this, existingAccessory, appliance.id);
           } else if (appliance.type === 'AC') {
-            new NatureNemoAirConAccessory(this, existingAccessory);
+            new NatureNemoAirConAccessory(this, existingAccessory, appliance.id);
           }
         } else {
           this.logger.info('Adding new accessory:', appliance.nickname);
           const accessory = new this.api.platformAccessory(appliance.nickname, appliance.id);
           accessory.context = { appliance: appliance };
           if (appliance.type === 'LIGHT') {
-            new NatureNemoLightAccessory(this, accessory);
+            new NatureNemoLightAccessory(this, accessory, appliance.id);
           } else if (appliance.type === 'AC') {
-            new NatureNemoAirConAccessory(this, accessory);
+            new NatureNemoAirConAccessory(this, accessory, appliance.id);
           }
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
         }

--- a/src/sensorAccessory.ts
+++ b/src/sensorAccessory.ts
@@ -17,11 +17,12 @@ export class NatureNemoSensorAccessory {
   constructor(
     private readonly platform: NatureRemoPlatform,
     private readonly accessory: PlatformAccessory,
+    private readonly serial_number: string,
   ) {
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Nature Inc.')
       .setCharacteristic(this.platform.Characteristic.Model, 'Nature Remo series')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'S-e-r-i-a-l');
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, serial_number);
 
     this.service
       = this.accessory.getService(this.platform.Service.TemperatureSensor)


### PR DESCRIPTION
Trying to control homekit devices from home assistant doesn't work properly because it doesn't like having entities of the same type sharing serial numbers. Using the actual serial number if available, or the appliance id as the serial number makes all appliances show up properly in home assistant.